### PR TITLE
Fixed non-SuperAdmin users accessibility in user profile

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -51,7 +51,7 @@ $pages = [
   "assignment-form" => ["roles" => ["Admin", "SuperAdmin"]],
   "dashboard"       => ["roles" => ["Faculty", "Staff", "Admin", "SuperAdmin"]],
   "edit-asset-form" => ["roles" => ["Admin", "SuperAdmin"]],
-  "edit-user-form"  => ["roles" => ["SuperAdmin"]],
+  "edit-user-form"  => ["roles" => ["Admin", "SuperAdmin"]],
   "login"           => ["roles" => []], // Allows everyone
   "return-form"     => ["roles" => ["Admin", "SuperAdmin"]],
   "user-manager"    => ["roles" => ["SuperAdmin"]],

--- a/public/script/edit-user.js
+++ b/public/script/edit-user.js
@@ -4,6 +4,7 @@ import { fetchUser } from "./user-router.js";
 
 const urlParams = new URLSearchParams(window.location.search);
 const userData = await fetchUser(urlParams.get("empID"));
+const sessionUserData = await fetchSessionUser();
 
 const userForm = document.querySelector("form"); 
 const assignmentTable = document.querySelector(".assignment-table");
@@ -18,6 +19,8 @@ userForm.action = `${window.location.origin}/api/index.php?resource=users&action
 userForm.method = "post";
 
 const user = Array.isArray(userData) ? userData[0] : userData;
+const sessionUser = sessionUserData;
+const isSuperAdmin = sessionUser?.Privilege === "SuperAdmin";
 
 fillForm(user);
 fetchAssignments();
@@ -28,6 +31,18 @@ input.type = "hidden";
 input.name = "employee-id";
 input.value = user["EmpID"];
 userForm.appendChild(input);
+
+// add session user role as hidden input for backend validation
+const sessionRoleInput = document.createElement("input");
+sessionRoleInput.type = "hidden";
+sessionRoleInput.name = "session-user-role";
+sessionRoleInput.value = sessionUser?.Privilege || "";
+userForm.appendChild(sessionRoleInput);
+
+// trabsform form to read-only for non SuperAdmin users
+if (!isSuperAdmin) {
+  transformFormToReadOnly();
+}
 
 const resetBtn = document.getElementById("reset-button");
 resetBtn?.addEventListener("click", (_) => {
@@ -203,4 +218,80 @@ function showAssignments() {
 
     assignmentTableBody.appendChild(tr);
   }
+}
+
+async function fetchSessionUser() {
+  const url = new URL(`${window.location.origin}/api/index.php`);
+  url.search = new URLSearchParams({
+    resource: "users",
+    action: "session",
+  });
+
+  try {
+    const resp = await fetch(url);
+    if (!resp.ok) throw new Error(`HTTP error! status: ${resp.status}`);
+    const data = await resp.json();
+    return data;
+  } catch (err) {
+    console.error("Error fetching session user: ", err);
+    return null;
+  }
+}
+
+function transformFormToReadOnly() {
+  const formTitle = document.querySelectorAll(".card")[0].querySelector("h3").textContent = "User Details";
+
+  // just disable the inputs and add a not-allowed cursor so the UI doesn't feel empty
+  const textInputs = userForm.querySelectorAll('input[type="text"], input[type="email"]');
+  for (const input of textInputs) {
+    input.disabled = true;
+    input.style.cursor = "not-allowed";
+  }
+
+  const radioGroups = new Map();
+  const radioInputs = userForm.querySelectorAll('input[type="radio"]');
+  for (const input of radioInputs) {
+    if (!radioGroups.has(input.name)) {
+      radioGroups.set(input.name, []);
+    }
+    radioGroups.get(input.name).push(input);
+  }
+
+  // for each radio group, display the selected value
+  for (const [groupName, inputs] of radioGroups) {
+    const checkedInput = inputs.find(input => input.checked);
+    if (checkedInput) {
+      const label = checkedInput.closest('label');
+      if (label) {
+        const displaySpan = document.createElement('span');
+        
+        if (groupName === 'active-status') {
+          const badgeSpan = document.createElement('span');
+          badgeSpan.className = `badge ${checkedInput.value.toLowerCase()}`;
+          badgeSpan.textContent = checkedInput.value;
+          displaySpan.appendChild(badgeSpan);
+          displaySpan.style.cssText = "display: inline-block; padding: 0.5rem;";
+        } else {
+          displaySpan.textContent = checkedInput.value;
+          displaySpan.style.cssText = "display: inline-block; padding: 0.5rem;";
+        }
+        
+        label.replaceWith(displaySpan);
+      }
+    }
+    
+    // remove unchecked radio inputs
+    for (const input of inputs) {
+      const label = input.closest('label');
+      if (label && !input.checked) {
+        label.remove();
+      }
+    }
+  }
+
+  // remove reset and submit button
+  const resetBtn = document.getElementById("reset-button");
+  const submitBtn = userForm.querySelector('button[type="submit"]');
+  resetBtn?.remove();
+  submitBtn?.remove();
 }

--- a/public/script/edit-user.js
+++ b/public/script/edit-user.js
@@ -20,9 +20,9 @@ userForm.method = "post";
 
 const user = Array.isArray(userData) ? userData[0] : userData;
 const sessionUser = sessionUserData;
-const isSuperAdmin = sessionUser?.Privilege === "SuperAdmin";
 
 fillForm(user);
+fillReadOnly(user);
 fetchAssignments();
 fetchLogs({actorID: user.EmpID});
 
@@ -38,11 +38,6 @@ sessionRoleInput.type = "hidden";
 sessionRoleInput.name = "session-user-role";
 sessionRoleInput.value = sessionUser?.Privilege || "";
 userForm.appendChild(sessionRoleInput);
-
-// trabsform form to read-only for non SuperAdmin users
-if (!isSuperAdmin) {
-  transformFormToReadOnly();
-}
 
 const resetBtn = document.getElementById("reset-button");
 resetBtn?.addEventListener("click", (_) => {
@@ -238,60 +233,18 @@ async function fetchSessionUser() {
   }
 }
 
-function transformFormToReadOnly() {
-  const formTitle = document.querySelectorAll(".card")[0].querySelector("h3").textContent = "User Details";
+function fillReadOnly(user) {
+  // only fill if read-only display fields exist (for Admin users)
+  const privilegeDisplay = document.getElementById("privilege-display");
+  const statusDisplay = document.getElementById("status-display");
 
-  // just disable the inputs and add a not-allowed cursor so the UI doesn't feel empty
-  const textInputs = userForm.querySelectorAll('input[type="text"], input[type="email"]');
-  for (const input of textInputs) {
-    input.disabled = true;
-    input.style.cursor = "not-allowed";
+  if (privilegeDisplay) {
+    privilegeDisplay.innerHTML = `<strong>Privilege:</strong> <span style="display: inline-block; padding: 0.5rem;">${user['Privilege']}</span>`;
   }
 
-  const radioGroups = new Map();
-  const radioInputs = userForm.querySelectorAll('input[type="radio"]');
-  for (const input of radioInputs) {
-    if (!radioGroups.has(input.name)) {
-      radioGroups.set(input.name, []);
-    }
-    radioGroups.get(input.name).push(input);
+  if (statusDisplay) {
+    const badgeClass = user['ActiveStatus'].toLowerCase();
+    statusDisplay.innerHTML = `<strong>Status:</strong> <span style="display: inline-block; padding: 0.5rem;"><span class="badge ${badgeClass}">${user['ActiveStatus']}</span></span>`;
   }
-
-  // for each radio group, display the selected value
-  for (const [groupName, inputs] of radioGroups) {
-    const checkedInput = inputs.find(input => input.checked);
-    if (checkedInput) {
-      const label = checkedInput.closest('label');
-      if (label) {
-        const displaySpan = document.createElement('span');
-        
-        if (groupName === 'active-status') {
-          const badgeSpan = document.createElement('span');
-          badgeSpan.className = `badge ${checkedInput.value.toLowerCase()}`;
-          badgeSpan.textContent = checkedInput.value;
-          displaySpan.appendChild(badgeSpan);
-          displaySpan.style.cssText = "display: inline-block; padding: 0.5rem;";
-        } else {
-          displaySpan.textContent = checkedInput.value;
-          displaySpan.style.cssText = "display: inline-block; padding: 0.5rem;";
-        }
-        
-        label.replaceWith(displaySpan);
-      }
-    }
-    
-    // remove unchecked radio inputs
-    for (const input of inputs) {
-      const label = input.closest('label');
-      if (label && !input.checked) {
-        label.remove();
-      }
-    }
-  }
-
-  // remove reset and submit button
-  const resetBtn = document.getElementById("reset-button");
-  const submitBtn = userForm.querySelector('button[type="submit"]');
-  resetBtn?.remove();
-  submitBtn?.remove();
 }
+

--- a/src/handlers/user.php
+++ b/src/handlers/user.php
@@ -65,6 +65,12 @@ final class UserHandler {
   }
 
   public function editUser(User $user): void {
+    // Only SuperAdmin can edit user details
+    if (isset($_SESSION['privilege']) && $_SESSION['privilege'] !== 'SuperAdmin') {
+      http_response_code(403);
+      throw new Exception("Access denied: Only SuperAdmin can modify user details");
+    }
+
     $old = $this->userRepo->identify($user->empID);
     $diff = array_diff_assoc($user->jsonSerialize(), $old->jsonSerialize());
     if (empty($diff)) return;
@@ -95,6 +101,12 @@ final class UserHandler {
   }
 
   public function changeStatus(string $empID, bool $isActive): void {
+    // Only SuperAdmin can change user status
+    if (isset($_SESSION['privilege']) && $_SESSION['privilege'] !== 'SuperAdmin') {
+      http_response_code(403);
+      throw new Exception("Access denied: Only SuperAdmin can modify user status");
+    }
+
     $user = $this->userRepo->identify($empID);
     $user->isActive = $isActive;
 

--- a/src/views/edit-user-form.php
+++ b/src/views/edit-user-form.php
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
-  <?php include __DIR__ . '/../partials/head.php'?>
+  <?php 
+    include __DIR__ . '/../partials/head.php';
+    $isSuperAdmin = isset($_SESSION['privilege']) && $_SESSION['privilege'] === 'SuperAdmin';
+    $headingText = $isSuperAdmin ? 'Edit User Details' : 'User Details';
+  ?>
   <link rel="stylesheet" href="<?= BASE_URL ?>css/forms.css">
   <link rel="stylesheet" href="<?= BASE_URL ?>css/table.css">
   <style>
@@ -47,7 +51,7 @@
 
     <main>
       <div class="card">
-        <h3>Edit User Details</h3>
+        <h3><?= $headingText ?></h3>
         <?php include __DIR__ . '/user-form.php'?>
       </div>
     

--- a/src/views/user-form.php
+++ b/src/views/user-form.php
@@ -1,3 +1,7 @@
+<?php
+$isSuperAdmin = isset($_SESSION['privilege']) && $_SESSION['privilege'] === 'SuperAdmin';
+?>
+
 <form>
   <label class="input-label"> 
     First Name: 
@@ -9,6 +13,7 @@
       maxlength="20" 
       size="20" 
       required
+      <?= !$isSuperAdmin ? 'disabled' : '' ?>
     >
   </label>
 
@@ -22,6 +27,7 @@
       maxlength="20" 
       size="20" 
       required
+      <?= !$isSuperAdmin ? 'disabled' : '' ?>
     >
   </label>
 
@@ -35,9 +41,11 @@
       maxlength="50" 
       size="30" 
       required
+      <?= !$isSuperAdmin ? 'disabled' : '' ?>
     > 
   </label>
 
+  <?php if ($isSuperAdmin): ?>
   <label class="input-label"> 
     Privilege: 
     <label>
@@ -100,14 +108,21 @@
       <span class="badge inactive">Inactive</span>
     </label>
   </label>
+  <?php else: ?>
+  <!-- Read-only display for Admin users -->
+  <div id="privilege-display" class="input-label"></div>
+  <div id="status-display" class="input-label"></div>
+  <?php endif; ?>
 
+  <?php if ($isSuperAdmin): ?>
   <button id="reset-button" type="button">
     Reset Changes
   </button>
 
   <button id="submit-button" type="submit" name="action" value="submit">
     Submit
-  </button>  
+  </button>
+  <?php endif; ?>
 </form>
 
 <script type="module" defer>


### PR DESCRIPTION
### Problem
Previously, admins can press the `Profile` button of each user in `Users` user table. However, their accesses are denied as seen below.

<img width="2559" height="1399" alt="image" src="https://github.com/user-attachments/assets/d6cbadab-9ccd-47b1-9c02-9e6f72d45784" />
<img width="2553" height="1450" alt="image" src="https://github.com/user-attachments/assets/2299a870-c6c0-4f64-a67d-8561e78f270f" />

<br>
But the client wanted users who can assign/unassign assets to have the ability to do this while in user's profile, admins should be allowed in the page. However, they must be restricted in editing the user details since only SuperAdmins are allowed to do this.

### Changes made
**Frontend**
- Added `fillReadOnly()` function in `edit-user.js` that only fills if the read only elements exist.

**Backend**
- Dynamic DOM elements based on session vars in `user-form.php` and `edit-user-form.php`
- Added SuperAdmin validation in `editUser()` and `changeStatus()` functions to prevent non-SuperAdmin from changing any user details.

`edit-user-form` now looks like this when the user is **`Admin`**.
<img width="2559" height="1406" alt="image" src="https://github.com/user-attachments/assets/9469059c-660b-48bd-b3c3-81a500e884e1" />
