### PR TITLE
Fixed filters for mobile view

### DIFF
--- a/public/css/asset.css
+++ b/public/css/asset.css
@@ -8,26 +8,6 @@
   flex-wrap: wrap;
 }
 
-.left-asset, .right-asset {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  /* justify-content: center; */
-  gap: 2rem;
-  flex: 1 1 400px;
-  min-width: 300px;
-}
-
-.left-asset {
-  margin-left: 1rem;
-}
-
-.right-asset {
-  width: 100%;
-  max-width: 400px;
-  align-items: center;
-}
-
 #addAsset {
   display: flex;
   align-items: center;
@@ -56,7 +36,7 @@
     flex-wrap: wrap;
   }
 
-  .right-asset {
+  .right-page {
     align-items: center;
     justify-content: unset;
     flex: unset;

--- a/public/css/asset.css
+++ b/public/css/asset.css
@@ -2,9 +2,9 @@
   display: flex;
   align-items: flex-start;
   /* justify-content: center; */
-  margin-top: 2rem;
+  margin-top: 1.5rem;
   gap: 3rem;
-  padding: 1rem;
+  padding: 1.5rem;
   flex-wrap: wrap;
 }
 
@@ -34,12 +34,5 @@
     gap: 3rem;
     padding: 1rem;
     flex-wrap: wrap;
-  }
-
-  .right-page {
-    align-items: center;
-    justify-content: unset;
-    flex: unset;
-    margin-left: 1rem;
   }
 }

--- a/public/css/filters.css
+++ b/public/css/filters.css
@@ -136,21 +136,16 @@
 
 @media only screen and (max-width: 1100px) {
   #filter-box-inline {
-    width: 80%;
-    max-width: 320px;
+    width: clamp(300px, 40%, 320px);
     display: flex;
     flex-direction: column;
     justify-content: space-between;
     align-items: center;
     border: 1pt solid black;
-    box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
     border-radius: 1rem;
     padding: 1rem;
     background-color: var(--beige);
     gap: 1rem;
-  }
-
-  #filter-box-reg {
-    display: none;
   }
 }

--- a/public/css/filters.css
+++ b/public/css/filters.css
@@ -135,7 +135,7 @@
 }
 
 @media only screen and (max-width: 1100px) {
-  #filter-box-inline {
+  #filter-box-reg {
     width: clamp(300px, 40%, 320px);
     display: flex;
     flex-direction: column;

--- a/public/css/general.css
+++ b/public/css/general.css
@@ -231,12 +231,20 @@ button .material-icons {
   min-width: 300px;
 }
 
-.left-page {
-  margin-left: 1rem;
-}
-
 .right-page {
   width: 100%;
   max-width: 400px;
   align-items: center;
+}
+
+@media only screen and (max-width: 1100px) {
+  .right-page {
+    align-items: center;
+    justify-content: unset;
+    flex: unset;
+    margin-left: 1rem;
+  }
+  .left-page {
+    width: 94%;
+  }
 }

--- a/public/css/general.css
+++ b/public/css/general.css
@@ -220,3 +220,23 @@ button .material-icons {
   background-color: var(--primary-color);
   color: var(--beige);
 }
+
+.left-page, .right-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  /* justify-content: center; */
+  gap: 2rem;
+  flex: 1 1 400px;
+  min-width: 300px;
+}
+
+.left-page {
+  margin-left: 1rem;
+}
+
+.right-page {
+  width: 100%;
+  max-width: 400px;
+  align-items: center;
+}

--- a/public/css/user-table.css
+++ b/public/css/user-table.css
@@ -26,6 +26,7 @@
 .user-table td {
   white-space: normal;
   word-break: break-word;
+  width: 18%;
 }
 
 .user-table thead {
@@ -36,10 +37,6 @@
   position: sticky;
   top: 0;
   z-index: 5;
-}
-
-td, th {
-  width: 18%;
 }
 
 th:nth-child(5),

--- a/public/css/user.css
+++ b/public/css/user.css
@@ -8,26 +8,6 @@
   flex-wrap: wrap;
 }
 
-.left-user, .right-user {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  /* justify-content: center; */
-  gap: 2rem;
-  flex: 1 1 400px;
-  min-width: 300px;
-}
-
-.left-user {
-  margin-left: 1rem;
-}
-
-.right-user {
-  width: 100%;
-  max-width: 400px;
-  align-items: center;
-}
-
 /* add user form */
 #addUser {
   display: flex;
@@ -96,7 +76,7 @@ th:last-child {
     flex-wrap: wrap;
   }
 
-  .right-user {
+  .right-page {
     align-items: center;
     justify-content: unset;
     flex: unset;

--- a/public/css/user.css
+++ b/public/css/user.css
@@ -69,17 +69,9 @@ th:last-child {
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
     margin-top: 2rem;
     gap: 3rem;
     padding: 1rem;
     flex-wrap: wrap;
-  }
-
-  .right-page {
-    align-items: center;
-    justify-content: unset;
-    flex: unset;
-    margin-left: 1rem;
   }
 }

--- a/public/script/asset-table-manager.js
+++ b/public/script/asset-table-manager.js
@@ -1,7 +1,7 @@
 import { tableData } from "./asset-table.js";
 import { condemnAsset, relayPage} from "./asset-router.js";
 
-const leftAsset = document.querySelector(".left-asset");
+const leftAsset = document.querySelector(".left-page");
 const tableFuncs = leftAsset.querySelector(".table-func");
 const tableContainer = leftAsset.querySelector(".table-container");
 const assetTable = tableContainer.querySelector(".asset-table");
@@ -407,7 +407,7 @@ function addModifyButton() {
 }
 
 function addAssetAdd() {
-  const leftAsset = document.querySelector(".left-asset");
+  const leftAsset = document.querySelector(".left-page");
 
   const assetAdd = document.createElement("a");
   assetAdd.href = "?page=add-asset-form";

--- a/public/script/asset-table.js
+++ b/public/script/asset-table.js
@@ -1,6 +1,6 @@
 import { relayPage } from "./asset-router.js";
 
-const leftAsset = document.querySelector(".left-asset");
+const leftAsset = document.querySelector(".left-page");
 const tableContainer = leftAsset.querySelector(".table-container");
 const assetTable = tableContainer.querySelector(".asset-table");
 const assetTableBody = assetTable.querySelector("tbody");

--- a/public/script/assign-asset.js
+++ b/public/script/assign-asset.js
@@ -3,7 +3,7 @@ import { relayPage } from "./asset-router.js";
 
 const assetTable = document.querySelector(".asset-table");
 const assetTableBody = assetTable.querySelector("tbody");
-const leftAsset = document.querySelector(".left-asset");
+const leftAsset = document.querySelector(".left-page");
 const tableFuncs = leftAsset.querySelector(".table-func");
 const tableContainer = leftAsset.querySelector(".table-container");
 

--- a/public/script/filter-repositioner.js
+++ b/public/script/filter-repositioner.js
@@ -1,7 +1,7 @@
 const BREAKPOINT = 1100;
 const filterBox = document.getElementById("filter-box-reg");
-const leftUser = document.querySelector(".left-asset");
-const rightUser = document.querySelector(".right-asset");
+const leftUser = document.querySelector(".left-page");
+const rightUser = document.querySelector(".right-page");
 const tableFunc = leftUser.querySelector(".table-func");
 const generateReportBtn = rightUser.querySelector("#report");
 

--- a/public/script/filter-repositioner.js
+++ b/public/script/filter-repositioner.js
@@ -1,0 +1,41 @@
+const BREAKPOINT = 1100;
+const filterBox = document.getElementById("filter-box-reg");
+const leftUser = document.querySelector(".left-asset");
+const rightUser = document.querySelector(".right-asset");
+const tableFunc = leftUser.querySelector(".table-func");
+const generateReportBtn = rightUser.querySelector("#report");
+
+let currentPosition = "right"; // Default position on page load
+
+function repositionFilter() {
+  console.log("Repositioning filter box...");
+  const shouldBeOnLeft = window.innerWidth <= BREAKPOINT;
+  const targetPosition = shouldBeOnLeft ? "left" : "right";
+
+  console.log(`Current position: ${currentPosition}, Target position: ${targetPosition}`);
+  console.log(`Window width: ${window.innerWidth}px, should be on: ${targetPosition}`);
+  // Only move if position actually changed
+  if (currentPosition === targetPosition) return;
+
+  if (shouldBeOnLeft) {
+    // Move to left => insert before table functions
+    leftUser.insertBefore(filterBox, tableFunc);
+  } else {
+    // Move to right => insert as first child
+    rightUser.prepend(filterBox)
+  }
+
+  currentPosition = targetPosition;
+}
+
+// Initial positioning on page load
+repositionFilter();
+
+// Reposition on window resize
+window.addEventListener("resize", repositionFilter);
+
+// Also handle orientation change for mobile devices
+window.addEventListener("orientationchange", () => {
+  // Small delay to ensure dimensions are updated
+  setTimeout(repositionFilter, 100);
+});

--- a/public/script/user-table-manager.js
+++ b/public/script/user-table-manager.js
@@ -2,7 +2,7 @@ import { tableData, selectedRows, inMultiSelect, addCheckboxes } from "./user-ta
 import { modifyUser } from "./user-router.js";
 import { relayPage } from "./asset-router.js";
 
-const leftUser = document.querySelector(".left-user");
+const leftUser = document.querySelector(".left-page");
 const tableFuncs = leftUser.querySelector(".table-func");
 const tableContainer = leftUser.querySelector(".table-container");
 const userTable = tableContainer.querySelector(".user-table");

--- a/public/script/user-table.js
+++ b/public/script/user-table.js
@@ -1,6 +1,6 @@
 import { relayPage } from "./asset-router.js";
 
-const leftUser = document.querySelector(".left-user");
+const leftUser = document.querySelector(".left-page");
 const tableContainer = leftUser.querySelector(".table-container");
 const userTable = tableContainer.querySelector(".user-table");
 const userTableBody = userTable.querySelector("tbody");

--- a/src/views/asset-page.php
+++ b/src/views/asset-page.php
@@ -1,4 +1,4 @@
-<div class="left-asset">
+<div class="left-page">
   <div id="search-box">
     <input type="text" id="search-input" placeholder="Search asset">
     <span class="material-icons search-icon">search</span>
@@ -22,7 +22,7 @@
   </div>
 </div>
 
-<div class="right-asset">
+<div class="right-page">
   <div class="filter-box" id="filter-box-reg">
     <div class="head-filter">
       FILTERS

--- a/src/views/asset-page.php
+++ b/src/views/asset-page.php
@@ -79,3 +79,4 @@
 </div>
 
 <script src="<?= BASE_URL ?>script/asset-table.js" type="module" defer></script>
+<script src="<?= BASE_URL ?>script/filter-repositioner.js" type="module" defer></script>

--- a/src/views/user-page.php
+++ b/src/views/user-page.php
@@ -1,48 +1,7 @@
-<div class="left-user">
+<div class="left-page">
   <div id="search-box">
     <input type="search" id="search-input" placeholder="Search user">
     <span class="material-icons search-icon">search</span>
-  </div>
-
-  <div class="filter-box" id="filter-box-inline">
-    <div class="head-filter">
-      FILTERS
-    </div>
-
-    <div class="body-filter">
-      <label>
-        <input type="checkbox" name="privilege" value="Faculty"> 
-        Faculty
-      </label>
-      <label>
-        <input type="checkbox" name="privilege" value="Staff"> 
-        Staff
-      </label>
-      <label>
-        <input type="checkbox" name="privilege" value="Admin"> 
-        Admin
-      </label>
-      <label>
-        <input type="checkbox" name="privilege" value="SuperAdmin"> 
-        SuperAdmin
-      </label>
-    </div>
-
-    <div class="body-filter">
-      <label>
-        <input type="checkbox" name="status" value="Active"> 
-        <span class="badge active">Active</span>
-      </label>
-      <label>
-        <input type="checkbox" name="status" value="Inactive"> 
-        <span class="badge inactive">Inactive</span>
-      </label>
-    </div>
-      
-    <button class="reset-filter"> 
-      <span class="material-icons">refresh</span>
-      Reset Filters 
-    </button>
   </div>
 
   <div class="table-container">
@@ -60,7 +19,7 @@
     </table>
   </div>
 </div>
-<div class="right-user">
+<div class="right-page">
   <div class="filter-box" id="filter-box-reg">
     <div class="head-filter">
       FILTERS
@@ -108,3 +67,4 @@
 </div>
 
 <script src="<?= BASE_URL ?>script/user-table.js" type="module" defer></script>
+<script src="<?= BASE_URL ?>script/filter-repositioner.js" type="module" defer></script>


### PR DESCRIPTION
## Description
Fixed the filters for mobile view (<1100 px display width). Also fixed weird user table width during mobile view.

## Changes
- Added `filter-repositioner.js` that repositions the filter to either below the search bar, or above the export button.
- Merged `.left-asset` and `.left-user` to `.left-page` and `.right-asset` and `.right-user` to `.right-page` since there is no reason to separate them, since these are mere containers.
- Changed everything related accordingly
- Set the width of left-page container to be `94%` during mobile view, so its consistent amongst user ang asset pages.

## Demonstration
### Asset table filters (persistent, one source of truth)
<img width="1080" height="608" alt="2026-05-03 20-29-42 (2)" src="https://github.com/user-attachments/assets/509d70fa-9ec0-4f57-92d4-f271d93d49aa" />

### User table filters
<img width="1080" height="608" alt="2026-05-03 20-30-34" src="https://github.com/user-attachments/assets/5515bcc8-f30c-4ce7-8e67-ab22a2456d88" />