### PR TITLE
Condemned reports

### DIFF
--- a/public/css/utils/export.css
+++ b/public/css/utils/export.css
@@ -18,103 +18,103 @@ body {
   background-color: #fff;
 }
 
+.report-header {
+  text-align: center;
+  margin-bottom: 10px;
+}
+
+.report-meta {
+  text-align: center;
+  font-size: 11px;
+  color: #636e72;
+  margin-top: -15px;
+  margin-bottom: 20px;
+}
+
+
 h1 {
   text-align: center;
   color: #2d3436;
   text-transform: uppercase;
-  letter-spacing: 2px;
+  letter-spacing: 1.5px;
   border-bottom: 2px solid var(--primary-color);
-  padding-bottom: 10px;
-  margin-bottom: 30px;
+  padding-bottom: 12px;
+  margin-bottom: 25px;
+  font-size: 18px;
 }
 
 .asset-container {
   margin-bottom: 25px;
+  border: 1px solid #dfe6e9;
+  border-radius: 6px;
+  overflow: hidden;
 }
 
 .asset-header {
   background-color: #3d0505;
   color: #ffffff;
   padding: 10px 15px;
-  font-size: 14px;
-  font-weight: bold;
-  border-radius: 4px 4px 0 0;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
 }
 
 table {
   width: 100%;
   border-collapse: collapse;
-  margin-top: 0;
-  border: 1px solid #dfe6e9;
-  page-break-inside: auto;
   table-layout: fixed;
 }
 
-tr {
-  break-inside: avoid;
-}
-
-th, td {
-  text-align: left;
-  border-bottom: 1px solid #dfe6e9;
+thead th {
+  height: 20px;
+  line-height: 1.2;
+  vertical-align: middle;
+  white-space: nowrap;
+  background-color: var(--primary-color) !important;
+  color: #ffffff !important;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 10px 12px;
+  border-bottom: 2px solid #3d0505;
 }
 
 td {
-  padding: 5px 15px;
+  padding: 8px 12px;
   font-size: 12px;
+  vertical-align: top;
+  border-bottom: 1px solid #e5e5e5;
 }
 
-th {
-  padding: 12px 15px;
-  background-color: #f8f9fa;
-  color: var(--primary-color);
-  font-weight: 600;
-  text-transform: uppercase;
-  font-size: 11px;
-}
-
-thead th {
-  background-color: var(--primary-color) !important; 
-  color: #ffffff !important;
-  border-bottom: none;
-  width: auto; 
-}
-
-
-thead tr {
-  background-color: transparent !important;
-}
-
-tr:nth-child(even) {
-  background-color: #f4efea;
+tbody tr:nth-child(even) {
+  background-color: #f7f3f0;
 }
 
 .remarks-cell {
-  word-break: break-word; 
+  word-break: break-word;
   color: #636e72;
   font-style: italic;
-  white-space: normal;
 }
 
 .empty {
+  text-align: center;
+  padding: 20px;
   color: #2d3436;
-  font-size: 1rem;
+  font-size: 13px;
 }
 
 footer {
   position: fixed;
-  bottom: 10px;
+  bottom: 12px;
   left: 0;
   width: 100%;
   padding: 0 20px;
-  box-sizing: border-box; 
-  display: flex;
-  align-items: center;
-  font-size: 0.8em;
+  box-sizing: border-box;
+  font-size: 11px;
+  color: #636e72;
 }
 
 footer .page {
-  margin: 0 auto; 
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
@@ -123,4 +123,8 @@ footer .page {
 footer .page::after {
   content: counter(page, decimal);
 }
-@page { margin: 20px 30px 40px 50px; }
+
+tr {
+  break-inside: avoid;
+  page-break-inside: avoid;
+}

--- a/public/css/utils/export.css
+++ b/public/css/utils/export.css
@@ -93,6 +93,7 @@ tr:nth-child(even) {
   word-break: break-word; 
   color: #636e72;
   font-style: italic;
+  white-space: normal;
 }
 
 .empty {

--- a/public/script/asset-table-manager.js
+++ b/public/script/asset-table-manager.js
@@ -115,6 +115,8 @@ document.addEventListener("click", async (e) => {
       url = `${window.location.origin}/api/index.php?resource=export&action=user-assets`;
     } else if (type === "unassigned") {
       url = `${window.location.origin}/api/index.php?resource=export&action=status&status=Unassigned`;
+    } else if (type === "condemned") {
+      url = `${window.location.origin}/api/index.php?resource=export&action=status&status=Condemned`
     } else {
       url = `${window.location.origin}/api/index.php?resource=export&action=status&status=ToCondemn`;
     }
@@ -450,6 +452,9 @@ function addReportModal() {
         </button>
         <button class="report-option" data-type="tocondemn"> 
           All Assets to be Condemned
+        </button>
+        <button class="report-option" data-type="condemned">
+          All Condemned Assets
         </button>
         <button class="report-option" data-type="unassigned">
           All Unassigned Assets

--- a/src/handlers/export.php
+++ b/src/handlers/export.php
@@ -68,7 +68,7 @@ final class ExportHandler {
     });
 
     $this->generatePdf(
-      template: "condemn-unassigned-assets",
+      template: "status-assets",
       data: [
         "assets"      => $assets,
         "statusName"  => $statusName,

--- a/src/handlers/export.php
+++ b/src/handlers/export.php
@@ -90,7 +90,8 @@ final class ExportHandler {
       $data[] = [
         'asset' => [
           $asset,
-          explode(' ', $this->assignRepo->getAssignmentDate($asset))[0]
+          explode(' ', $this->assignRepo->getAssignmentDate($asset))[0],
+          $this->assignRepo->getAssignmentRemarks($asset)
         ]
       ];
     }
@@ -119,7 +120,6 @@ final class ExportHandler {
 
     foreach ($usersID as $id) {
       $user = $this->userRepo->identify($id);
-
       $assets = $this->assignRepo->getAssignedAssets($user);
 
       usort($assets, function ($a, $b) {
@@ -129,16 +129,19 @@ final class ExportHandler {
         return $dateB <=> $dateA;
       });
 
-      $assetDates = [];
+      $assignDates = [];
+      $assignRemarks = [];
 
       foreach ($assets as $asset) {
-        $assetDates[$asset->propNum] = explode(' ', $this->assignRepo->getAssignmentDate($asset))[0];
+        $assignDates[$asset->propNum] = explode(' ', $this->assignRepo->getAssignmentDate($asset))[0];
+        $assignRemarks[$asset->propNum] = $this->assignRepo->getAssignmentRemarks($asset);
       }
 
       $data[] = [
         "user"        => $user,
         "assets"      => $assets,
-        "assignDates" => $assetDates,
+        "assignDates" => $assignDates,
+        "assignRemarks" => $assignRemarks
       ];
     }
 

--- a/src/repos/assignment.php
+++ b/src/repos/assignment.php
@@ -9,6 +9,7 @@ interface AssignmentRepoInterface {
   public function getAssignedAssets(User $user): array;
   public function getCurrAssignedUser(Asset $asset): ?User; 
   public function getAssignmentDate(Asset $asset): string; 
+  public function getAssignmentRemarks(Asset $asset): string;
   public function assign(
     Asset $asset, 
     User $assigner,
@@ -65,6 +66,16 @@ final class AssignmentRepo implements AssignmentRepoInterface {
     $stmt->execute([":pnum" => $asset->propNum]);
     $res = $stmt->fetchAll(PDO::FETCH_ASSOC);
     return $res[0]['AssignDateTime'];
+  }
+
+  public function getAssignmentRemarks(Asset $asset): string {
+    $query = "SELECT * FROM 
+      assignment WHERE PropNum = :pnum AND ReturnDateTime is NULL";
+    
+    $stmt = $this->pdo->prepare($query);
+    $stmt->execute([":pnum" => $asset->propNum]);
+    $res = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    return $res[0]['Remarks'];
   }
 
   public function getAssignedAssets(User $user): array {

--- a/src/template/assigned-assets.php
+++ b/src/template/assigned-assets.php
@@ -4,7 +4,14 @@
     <meta charset="UTF-8">
   </head>
 <body>
-    <h1>Assets Currently Assigned</h1>
+
+    <div class="report-header">
+      <h1>Assets Currently Assigned</h1>
+      <div class="report-meta">
+        As of <?= date("F d, Y") ?>
+      </div>
+    </div>
+
     <div class="asset-container">
       <?php if (!empty($assets)): ?>
         <?php 

--- a/src/template/assigned-assets.php
+++ b/src/template/assigned-assets.php
@@ -39,9 +39,9 @@
                 <td><?= htmlspecialchars($asset->serialNum) ?></td>
                 <td><?= htmlspecialchars($assDate) ?></td>
                 <td><?= htmlspecialchars($asset->specs !== ''? $asset->specs: 'None') ?></td>
-                <td><?=  htmlspecialchars($asset->description !== '' ? $asset->description : 'None') ?></td>
+                <td><?=  htmlspecialchars($asset->description !== '' ? (strlen($asset->description) > 300 ? substr($asset->description,0,300) . '...' : $asset->description) : 'None') ?></td>
                 <?php if ($add_remarks): ?>
-                  <td class="remarks-cell"><?= htmlspecialchars($asset->remarks !== '' ? $asset->remarks: 'None') ?></td>
+                  <td class="remarks-cell"><?= htmlspecialchars($asset->remarks !== '' ? (strlen($asset->remarks) > 300 ? substr($asset->remarks,0,300) . '...' : $asset->remarks) : 'None') ?></td>
                 <?php endif ?>
               </tr>
             <?php endforeach; ?>

--- a/src/template/assigned-assets.php
+++ b/src/template/assigned-assets.php
@@ -33,6 +33,7 @@
                 $assetDetails = $d['asset'];
                 $asset = $assetDetails[0];
                 $assDate = $assetDetails[1];
+                $assignRemarks = $assetDetails[2];
               ?>
               <tr>
                 <td><?= htmlspecialchars($asset->propNum) ?></td> 
@@ -41,7 +42,7 @@
                 <td><?= htmlspecialchars($asset->specs !== ''? $asset->specs: 'None') ?></td>
                 <td><?=  htmlspecialchars($asset->description !== '' ? (strlen($asset->description) > 300 ? substr($asset->description,0,300) . '...' : $asset->description) : 'None') ?></td>
                 <?php if ($add_remarks): ?>
-                  <td class="remarks-cell"><?= htmlspecialchars($asset->remarks !== '' ? (strlen($asset->remarks) > 300 ? substr($asset->remarks,0,300) . '...' : $asset->remarks) : 'None') ?></td>
+                  <td class="remarks-cell"><?= htmlspecialchars($assignRemarks !== '' ? (strlen($assignRemarks) > 300 ? substr($assignRemarks,0,300) . '...' : $assignRemarks) : 'None') ?></td>
                 <?php endif ?>
               </tr>
             <?php endforeach; ?>

--- a/src/template/faculty-assigned-assets.php
+++ b/src/template/faculty-assigned-assets.php
@@ -6,10 +6,11 @@
   <body>
     <h1>All Faculty Assigned Assets</h1>
     <?php foreach ($data as $d): ?>
-      <?php 
+      <?php
         $user   = $d['user'];
         $assets = $d['assets'];
-        $dates  = $d['assignDates'];
+        $assignDates  = $d['assignDates'];
+        $assignRemarks = $d['assignRemarks'];
 
         $fullName = trim("{$user->name->first} {$user->name->last}");
         $priv     = $user->privilege->value;
@@ -37,10 +38,10 @@
               <tr>
                   <td><?= htmlspecialchars($asset->propNum) ?></td>
                   <td><?= htmlspecialchars($asset->serialNum) ?></td>
-                  <td><?= htmlspecialchars($dates[$asset->propNum]) ?></td>
+                  <td><?= htmlspecialchars($assignDates[$asset->propNum]) ?></td>
                   <td><?=  htmlspecialchars($asset->description !== '' ? (strlen($asset->description) > 300 ? substr($asset->description,0,300) . '...' : $asset->description) : 'None') ?></td>
                   <?php if ($add_remarks): ?>
-                    <td class="remarks-cell"><?= htmlspecialchars($asset->remarks !== '' ? (strlen($asset->remarks) > 300 ? substr($asset->remarks,0,300) . '...' : $asset->remarks) : 'None') ?></td>
+                    <td class="remarks-cell"><?= htmlspecialchars($assignRemarks[$asset->propNum] !== '' ? (strlen($assignRemarks[$asset->propNum]) > 300 ? substr($assignRemarks[$asset->propNum],0,300) . '...' : $assignRemarks[$asset->propNum]) : 'None') ?></td>
                   <?php endif ?>
               </tr>
             <?php endforeach; ?>

--- a/src/template/faculty-assigned-assets.php
+++ b/src/template/faculty-assigned-assets.php
@@ -38,9 +38,9 @@
                   <td><?= htmlspecialchars($asset->propNum) ?></td>
                   <td><?= htmlspecialchars($asset->serialNum) ?></td>
                   <td><?= htmlspecialchars($dates[$asset->propNum]) ?></td>
-                  <td><?=  htmlspecialchars($asset->description !== '' ? $asset->description : 'None') ?></td>
+                  <td><?=  htmlspecialchars($asset->description !== '' ? (strlen($asset->description) > 300 ? substr($asset->description,0,300) . '...' : $asset->description) : 'None') ?></td>
                   <?php if ($add_remarks): ?>
-                    <td class="remarks-cell"><?= htmlspecialchars($asset->remarks !== '' ? $asset->remarks: 'None') ?></td>
+                    <td class="remarks-cell"><?= htmlspecialchars($asset->remarks !== '' ? (strlen($asset->remarks) > 300 ? substr($asset->remarks,0,300) . '...' : $asset->remarks) : 'None') ?></td>
                   <?php endif ?>
               </tr>
             <?php endforeach; ?>

--- a/src/template/faculty-assigned-assets.php
+++ b/src/template/faculty-assigned-assets.php
@@ -4,7 +4,12 @@
     <meta charset="UTF-8">
   </head>
   <body>
-    <h1>All Faculty Assigned Assets</h1>
+    <div class="report-header">
+      <h1>All Faculty Assigned Assets</h1>
+      <div class="report-meta">
+        As of <?= date("F d, Y") ?>
+      </div>
+    </div>
     <?php foreach ($data as $d): ?>
       <?php
         $user   = $d['user'];

--- a/src/template/status-assets.php
+++ b/src/template/status-assets.php
@@ -5,9 +5,16 @@
   </head>
   <body>
     <?php 
-      $title = ($statusName == "ToCondemn") ? "TO BE CONDEMNED" : "THAT ARE UNASSIGNED";
+      $title = "";
+      if ($statusName == "Condemned") {
+        $title = "CONDEMNED";
+      } elseif ($statusName == "ToCondemn") {
+        $title = "TO-BE-CONDEMNED";
+      } else {
+        $title = "UNASSIGNED";
+      }
     ?>
-    <h1>All Assets <?= htmlspecialchars($title) ?></h1>
+    <h1> ALL <?= htmlspecialchars($title) ?> ASSETS</h1>
     <div class="asset-container">
       <?php if (!empty($assets)): ?>
       <table>

--- a/src/template/status-assets.php
+++ b/src/template/status-assets.php
@@ -3,18 +3,27 @@
   <head>
     <meta charset="UTF-8">
   </head>
+
   <body>
     <?php 
       $title = "";
       if ($statusName == "Condemned") {
         $title = "CONDEMNED";
       } elseif ($statusName == "ToCondemn") {
-        $title = "TO-BE-CONDEMNED";
+        $title = "TO BE CONDEMNED";
       } else {
         $title = "UNASSIGNED";
       }
     ?>
-    <h1> ALL <?= htmlspecialchars($title) ?> ASSETS</h1>
+
+    <div class="report-header">
+      <h1>ALL <?= htmlspecialchars($title) ?> ASSETS</h1>
+      <div class="report-meta">
+        As of <?= date("F d, Y") ?>
+      </div>
+    </div>
+
+
     <div class="asset-container">
       <?php if (!empty($assets)): ?>
       <table>
@@ -25,28 +34,50 @@
             <th> Acquisition Date </th>
             <th> Description </th>
             <?php if ($add_remarks): ?>
-              <th> Remarks  </th>
+              <th> Remarks </th>
             <?php endif ?>
           </tr>
         </thead>
+
         <tbody>
           <?php foreach ($assets as $asset): ?>
             <tr>
-              <td><?=  htmlspecialchars($asset->propNum) ?></td>
-              <td><?=  htmlspecialchars($asset->serialNum) ?></td>
-              <td><?=  htmlspecialchars($asset->purchaseDate) ?></td>
-              <td><?=  htmlspecialchars($asset->description !== '' ? (strlen($asset->description) > 300 ? substr($asset->description,0,300) . '...' : $asset->description) : 'None') ?></td>
+              <td><?= htmlspecialchars($asset->propNum) ?></td>
+              <td><?= htmlspecialchars($asset->serialNum) ?></td>
+              <td><?= htmlspecialchars($asset->purchaseDate) ?></td>
+              <td>
+                <?= htmlspecialchars(
+                  $asset->description !== '' 
+                    ? (strlen($asset->description) > 300 
+                        ? substr($asset->description,0,300) . '...' 
+                        : $asset->description) 
+                    : 'None'
+                ) ?>
+              </td>
+
               <?php if ($add_remarks): ?>
-                <td class="remarks-cell"><?= htmlspecialchars($asset->remarks !== '' ? (strlen($asset->remarks) > 300 ? substr($asset->remarks,0,300) . '...' : $asset->remarks) : 'None') ?></td>
+                <td class="remarks-cell">
+                  <?= htmlspecialchars(
+                    $asset->remarks !== '' 
+                      ? (strlen($asset->remarks) > 300 
+                          ? substr($asset->remarks,0,300) . '...' 
+                          : $asset->remarks) 
+                      : 'None'
+                  ) ?>
+                </td>
               <?php endif ?>
             </tr>
           <?php endforeach; ?>
         </tbody>
+
       </table>
+
       <?php else: ?>
-        <p class="empty"> No <?= htmlspecialchars(strtolower($statusName)) ?> assets</p>
+        <p class="empty">No <?= htmlspecialchars(strtolower($statusName)) ?> assets</p>
       <?php endif; ?>
+
     </div>
+
   </body>
   <footer>
     <p class="page">Page </p>

--- a/src/template/status-assets.php
+++ b/src/template/status-assets.php
@@ -35,9 +35,9 @@
               <td><?=  htmlspecialchars($asset->propNum) ?></td>
               <td><?=  htmlspecialchars($asset->serialNum) ?></td>
               <td><?=  htmlspecialchars($asset->purchaseDate) ?></td>
-              <td><?=  htmlspecialchars($asset->description !== '' ? $asset->description : 'None') ?></td>
+              <td><?=  htmlspecialchars($asset->description !== '' ? (strlen($asset->description) > 300 ? substr($asset->description,0,300) . '...' : $asset->description) : 'None') ?></td>
               <?php if ($add_remarks): ?>
-                <td class="remarks-cell"><?= htmlspecialchars($asset->remarks !== '' ? $asset->remarks: 'None') ?></td>
+                <td class="remarks-cell"><?= htmlspecialchars($asset->remarks !== '' ? (strlen($asset->remarks) > 300 ? substr($asset->remarks,0,300) . '...' : $asset->remarks) : 'None') ?></td>
               <?php endif ?>
             </tr>
           <?php endforeach; ?>


### PR DESCRIPTION
- Add an option to generate reports for condemned assets
- Fix the length of the description and remarks displayed in the reports
- Display the date when reports are generated
- Update assignment reports to display assignment remarks instead of asset remarks

<img width="1909" height="869" alt="image" src="https://github.com/user-attachments/assets/9f8111bd-a69b-4792-a3ba-bc6821119114" />
<img width="989" height="799" alt="image" src="https://github.com/user-attachments/assets/f25ae6d1-62db-47c1-9105-a5ce3d0ef882" />

<img width="993" height="714" alt="image" src="https://github.com/user-attachments/assets/76ccfa51-2bc7-4666-9a5f-9f4d91087b56" />
<img width="1002" height="756" alt="image" src="https://github.com/user-attachments/assets/a61307d7-f3f5-4f39-b387-5d0960e7a22e" />

